### PR TITLE
fix: fix textInput styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rustic-ai/ui-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rustic-ai/ui-components",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustic-ai/ui-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "keywords": [
     "rustic-ai",
     "conversational-ui"

--- a/src/components/input/baseInput/baseInput.css
+++ b/src/components/input/baseInput/baseInput.css
@@ -36,7 +36,7 @@
 }
 
 .rustic-base-input .rustic-send-button {
-  margin: 10px 12px;
+  margin: 13px 12px 12px;
 }
 
 .rustic-base-input .rustic-input-actions {

--- a/src/components/input/baseInput/baseInput.tsx
+++ b/src/components/input/baseInput/baseInput.tsx
@@ -427,6 +427,7 @@ function BaseInputElement(
           sx={{
             border: '1px solid',
             borderColor: isFocused ? 'secondary.main' : 'action.disabled',
+            backgroundColor: 'background.paper',
           }}
         >
           {emojiSearchResults.length > 0 && inputRef.current && (

--- a/src/components/input/multimodal/multimodalInput/multimodalInput.css
+++ b/src/components/input/multimodal/multimodalInput/multimodalInput.css
@@ -12,6 +12,10 @@
   gap: 0;
 }
 
+.rustic-multimodal-input .rustic-send-button {
+  margin: 10px 12px;
+}
+
 .rustic-multimodal-input .rustic-input-actions {
   width: 100%;
   position: relative;


### PR DESCRIPTION
## Changes
- fix textInput styling (Send button doesn't align with other icons. Didn't use background paper color within input box)

## Screenshot
I added blue background color for testing purpose. Storybook still shows white background color
### Before
<img width="534" height="105" alt="Screenshot 2025-07-21 at 3 41 24 PM" src="https://github.com/user-attachments/assets/936cc53a-c1fe-415b-8f12-51e3932d4887" />

### After
<img width="535" height="105" alt="Screenshot 2025-07-21 at 3 42 07 PM" src="https://github.com/user-attachments/assets/23140552-aa1f-4437-a7ad-335154509ec7" />
