### PR TITLE
feat(perspective): support date format customization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rustic-ai/ui-components",
-  "version": "0.1.2",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rustic-ai/ui-components",
-      "version": "0.1.2",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rustic-ai/ui-components",
-  "version": "0.1.2",
+  "version": "0.2.2",
   "keywords": [
     "rustic-ai",
     "conversational-ui"

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -198,6 +198,8 @@ export type TableConfig = {
   sort?: TableSort[]
   filter?: TableFilter[]
   expansionDepth?: number
+  dateColumns?: string[]
+  dateStyle?: 'full' | 'long' | 'medium' | 'short' | 'disabled'
 }
 
 export interface TableFormat extends VisualizationFormat {

--- a/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.stories.tsx
@@ -75,6 +75,10 @@ meta.argTypes = {
           '      "contains"\n' +
           '    - The value or an array of values used as\n' +
           '      criteria for filtering.\n' +
+          '  dateColumns: An array of columns which are of datetype. \n' +
+          '    Useful if you want to specify the format to show dates in \n' +
+          '  dateStyle: dateStyle option of Intl.DateTimeFormat - \n' +
+          '    "full" | "long" | "medium" | "short" | "disabled" \n' +
           '\n' +
           '`TableAggregateOption` supports the following values:\n' +
           '  `abs sum`|`and`|`any`|`avg`|`count`|`distinct count`\n' +
@@ -240,4 +244,29 @@ export const NoData = {
   args: {
     data: [],
   },
+}
+
+export const TableWithSimplerDate = {
+  args: {
+    data: generateFakeData(5),
+    headers: tableHeaders,
+    title: 'Table With Default Date Format',
+    config: {
+      dateColumns: ['Order Date'],
+    },
+  },
+  decorators,
+}
+
+export const TableWithFullDateFormat = {
+  args: {
+    data: generateFakeData(10),
+    headers: tableHeaders,
+    title: 'Table With Full Date',
+    config: {
+      dateColumns: ['Order Date'],
+      dateStyle: 'full',
+    },
+  },
+  decorators,
 }

--- a/src/components/visualization/perspectiveViz/perspectiveViz.tsx
+++ b/src/components/visualization/perspectiveViz/perspectiveViz.tsx
@@ -5,7 +5,10 @@ import '@finos/perspective-viewer/dist/css/pro.css'
 import '@finos/perspective-viewer/dist/css/pro-dark.css'
 
 import type { Client, Table, View } from '@finos/perspective'
-import type { HTMLPerspectiveViewerElement } from '@finos/perspective-viewer'
+import type {
+  ColumnConfigValues,
+  HTMLPerspectiveViewerElement,
+} from '@finos/perspective-viewer'
 import { useTheme } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
 import Stack from '@mui/system/Stack'
@@ -236,11 +239,23 @@ function PerspectiveViz(props: TableData) {
         })
         .then(() => {
           if (isMounted && viewer) {
+            const dateColConfig = {
+              date_format: {
+                dateStyle: props.config?.dateStyle || 'medium',
+              },
+            }
+            const colConfigs: { [columnName: string]: ColumnConfigValues } = {}
+            props.config?.dateColumns?.forEach((column_name) => {
+              // @ts-expect-error other fields are not needed for date formatting
+              colConfigs[column_name] = dateColConfig
+            })
+
             return viewer.restore({
               ...transformedConfig,
               theme: perspectiveTheme,
               title: props.title,
               settings: false,
+              columns_config: colConfigs,
             })
           }
         })


### PR DESCRIPTION
<img width="1323" height="1327" alt="Screenshot From 2025-09-02 18-48-13" src="https://github.com/user-attachments/assets/4fc42db9-8f09-4f0f-b9b8-74351897a9b5" />
<img width="1340" height="858" alt="Screenshot From 2025-09-02 18-49-10" src="https://github.com/user-attachments/assets/8a38d100-d37b-4b78-a507-b2298c0063d3" />
<img width="1340" height="858" alt="Screenshot From 2025-09-02 18-48-57" src="https://github.com/user-attachments/assets/aea2a8f0-322c-43e6-927c-a6d906b00186" />

